### PR TITLE
Migrated to ExprTools, added tests, added call_path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 .DS_Store
-./Manifest.toml
+Manifest.toml

--- a/Project.toml
+++ b/Project.toml
@@ -7,8 +7,8 @@ version = "0.1.0"
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
+ExprTools = "e2ba6199-217a-4e67-a87a-7c52f15ade04"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
-MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
 TimeZones = "f269a46b-ccf7-5d73-abea-4c690281aa53"
 
 [compat]

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ The `@memo` macro is used to append new data to the current context.  Consider t
 It would be translated to something like:
 
 ```julia
-val = 1
+val = (x = 1)
 push!(ContextTracking.context(), :x => val)
 ```
 

--- a/src/ContextTracking.jl
+++ b/src/ContextTracking.jl
@@ -3,11 +3,11 @@ module ContextTracking
 using Dates: now
 using DataStructures: Stack
 using DocStringExtensions
-using MacroTools: combinedef, splitdef, @capture
+using ExprTools: combinedef, splitdef
 
 export Context
 export context, save, restore
-export @ctx, @memo
+export @ctx, @memo, call_path
 export ContextLogger
 
 include("types.jl")

--- a/src/trace.jl
+++ b/src/trace.jl
@@ -29,14 +29,15 @@ end
     @memo var = expr
     @memo var
 
-Stroe the variable/value from the assigment statement in the current
+Store the variable/value from the assigment statement in the current
 context.
 """
 macro memo(ex)
-    if typeof(ex) === Symbol
+    # capture the variable
+    if ex isa Symbol          # @memo var
         x = ex
-    elseif @capture(ex, x_ = y_)
-        # intentionally blank since `x` and `y` are already assigned here
+    elseif ex.head === :(=)   # @memo var = expression
+        x = ex.args[1]
     else
         error("@memo must be followed by an assignment or a variable name.")
     end
@@ -61,3 +62,5 @@ function trace!(ctx::Context, name::Symbol)
     end
     return dct
 end
+
+call_path(ctx::Context{Dict{Any,Any}}) = get(ctx.data, CONTEXT_PATH_KEY, nothing)

--- a/src/trace.jl
+++ b/src/trace.jl
@@ -52,15 +52,26 @@ end
     trace!(ctx, name)
 
 Store the function name in the trace path in the context.
+Note that call path tracing only works for context
 """
-function trace!(ctx::Context, name::Symbol)
+function trace!(ctx::Context{Dict{T,S}}, name::Symbol) where {T >: String, S >: Symbol}
     dct = ctx.data
     if haskey(dct, CONTEXT_PATH_KEY)
         push!(dct[CONTEXT_PATH_KEY], name)
     else
         dct[CONTEXT_PATH_KEY] = Symbol[name]
     end
-    return dct
+    return nothing
 end
 
+# fallback
+trace!(ctx::Context, name::Symbol) = nothing
+
+"""
+    call_path(::Context{Dict{Any,Any}})
+
+Return the call path
+"""
 call_path(ctx::Context{Dict{Any,Any}}) = get(ctx.data, CONTEXT_PATH_KEY, nothing)
+
+call_path(ctx::T) where {T <: Context} = error("Call path unavailabe for this context type: $T")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,33 +2,6 @@ using ContextTracking
 using Test
 
 @testset "ContextTracking.jl" begin
-
-@testset "Basic Operation" begin
-    c = context()
-    @test c.generations == 1
-
-    # add entries to current context
-    push!(c, "key1" => 1)
-    push!(c, "key2" => "hey")
-    @test length(c) == 2
-    @test c.data["key1"] == 1
-    @test c.data["key2"] == "hey"
-
-    # save current context to stack
-    save(c)
-    @test c.generations == 2   # current + one saved context
-    @test length(c.data) == 2
-
-    # add more "color" to current context
-    push!(c, "key3" => :cool)
-    @test length(c.data) == 3
-    @test sort(collect(keys(c.data))) == ["key1", "key2", "key3"]
-
-    # restore the prior context
-    restore(c)
-    @test c.generations == 1
-    @test length(c.data) == 2
-    @test sort(collect(keys(c.data))) == ["key1", "key2"]
+    include("test_context.jl")
+    include("test_trace.jl")
 end
-
-end # outermost testset

--- a/test/test_context.jl
+++ b/test/test_context.jl
@@ -1,0 +1,43 @@
+# context data management tests
+
+@testset "Basic Operation" begin
+    c = context()
+    @test c.generations == 1
+
+    # add entries to current context
+    push!(c, "key1" => 1)
+    push!(c, "key2" => "hey")
+    @test length(c) == 2
+    @test c.data["key1"] == 1
+    @test c.data["key2"] == "hey"
+
+    # save current context to stack
+    save(c)
+    @test c.generations == 2   # current + one saved context
+    @test length(c.data) == 2
+
+    # add more "color" to current context
+    push!(c, "key3" => :cool)
+    @test length(c.data) == 3
+    @test sort(collect(keys(c.data))) == ["key1", "key2", "key3"]
+
+    # restore the prior context
+    restore(c)
+    @test c.generations == 1
+    @test length(c.data) == 2
+    @test sort(collect(keys(c.data))) == ["key1", "key2"]
+
+    # empty context data
+    empty!(c)
+    @test length(c.data) == 0
+end
+
+@testset "Non-Dict context data" begin
+    # create custom context; use random id to avoid getting the default
+    c = context(id = UInt(rand(UInt)), container = String[])
+    push!(c, "hello")
+    push!(c, "world")
+
+    @test length(c.data) == 2
+    @test c.data == [ "hello", "world"]
+end

--- a/test/test_trace.jl
+++ b/test/test_trace.jl
@@ -1,0 +1,27 @@
+# Test tracing functionalities
+
+module TracingTest
+    using ContextTracking
+    using Test
+
+    @ctx function foo()
+        @memo x = 1
+        me = "not visible downstream"
+        bar()
+    end
+
+    @ctx function bar()
+        @memo y = 2
+        baz()
+    end
+
+    @ctx function baz()
+        c = context()
+        @test call_path(c) == [:foo, :bar, :baz]
+        @test c.data[:x] == 1
+        @test c.data[:y] == 2
+        @test !haskey(c.data, :me)
+    end
+
+    __init__() = foo()
+end


### PR DESCRIPTION
1. Removed MacroTools dependency and migrated to ExprTools because I only need `splitdef`/`combinedef`
2. Added more tests for context data management
3. Added test for `@ctx` and `@memo` macros
4. Added a new `call_path` function

