### PR TITLE
♻️ Call path now in Context object

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # ContextTracking.jl
 
-ContextTracking is used to keep track of execution context.  The context data is kept in a stack data structure.  When a function is called, the context is saved.  When the function exits, the context is restored.  User can make changes to the context during execution, and the data is visible to both the current and deeper stack frames.  
+ContextTracking is used to keep track of execution context.  The context data is kept in a stack data structure.  When a function is called, the context is saved.  When the function exits, the context is restored.  User can make changes to the context during execution, and the data is visible to both the current and deeper stack frames.
 
 The usage is embarassingly simple:
 1. Annotate functions with `@ctx` macro
@@ -41,7 +41,6 @@ julia> foo()
 ┌ Info: context data
 │   c.data =
 │    Dict{Any,Any} with 2 entries:
-│      :_ContextPath_ => [:foo, :bar]
 └      :x             => 1
 ```
 

--- a/src/ContextTracking.jl
+++ b/src/ContextTracking.jl
@@ -7,7 +7,7 @@ using ExprTools: combinedef, splitdef
 
 export Context
 export context, save, restore
-export @ctx, @memo, call_path
+export @ctx, @memo
 
 include("types.jl")
 include("context.jl")

--- a/src/context.jl
+++ b/src/context.jl
@@ -5,7 +5,7 @@ Create a context with the provided container.
 function Context(id::UInt, container::T) where {T}
     history = Stack{T}()
     push!(history, container)
-    return Context(id, history)
+    return Context(id, history, Symbol[])
 end
 
 """
@@ -54,6 +54,7 @@ function Base.getproperty(c::Context, s::Symbol)
     s === :data && return first(getfield(c, :history))
     s === :generations && return length(getfield(c, :history))
     s === :hex_id && return string("0x", string(getfield(c, :id); base = 16))
+    s === :path && return getfield(c, :path)
     throw(UndefVarError("$s is not a valid property name."))
 end
 

--- a/src/trace.jl
+++ b/src/trace.jl
@@ -1,6 +1,3 @@
-"Special key for looking up the call path"
-const CALL_PATH_KEY = Symbol("_ContextPath_")
-
 """
     @ctx <function definition> [label]
 
@@ -8,9 +5,6 @@ Define a function that is context-aware i.e. save the current context
 before executing the function and restore the context right before
 returning to the caller. So, if the function modifies the context
 using (see [`@memo`](@ref)), then the change is not visible the caller.
-
-An optional label of type symbol/string can be added at the end of function definition for
-tracking the call path.  Function name is used when the label is not provided.
 ```
 """
 macro ctx(ex, label = nothing)
@@ -57,24 +51,7 @@ end
 Store the function name in the trace path in the context.
 Note that call path tracing only works for context
 """
-function trace!(ctx::Context{Dict{T,S}}, name::Symbol) where {T >: String, S >: Symbol}
-    dct = ctx.data
-    if haskey(dct, CALL_PATH_KEY)
-        push!(dct[CALL_PATH_KEY], name)
-    else
-        dct[CALL_PATH_KEY] = Symbol[name]
-    end
+function trace!(ctx::Context, name::Symbol)
+    push!(ctx.path, name)
     return nothing
 end
-
-# fallback
-trace!(ctx::Context, name::Symbol) = nothing
-
-"""
-    call_path(::Context{Dict{Any,Any}})
-
-Return the call path
-"""
-call_path(ctx::Context{Dict{Any,Any}}) = get(ctx.data, CALL_PATH_KEY, nothing)
-
-call_path(ctx::T) where {T <: Context} = error("Call path unavailabe for this context type: $T")

--- a/src/trace.jl
+++ b/src/trace.jl
@@ -46,14 +46,3 @@ macro memo(ex)
         push!(ContextTracking.context(), $sym => val)
     end
 end
-
-"""
-    trace!(ctx, name)
-
-Store the function name in the trace path in the context.
-Note that call path tracing only works for context
-"""
-function trace!(ctx::Context, name::Symbol)
-    push!(ctx.path, name)
-    return nothing
-end

--- a/src/trace.jl
+++ b/src/trace.jl
@@ -11,12 +11,14 @@ macro ctx(ex, label = nothing)
     def = splitdef(ex)
     name = QuoteNode(label !== nothing ? Symbol(label) : def[:name])
     def[:body] = quote
+        c = ContextTracking.context()
         try
-            save(ContextTracking.context())
-            ContextTracking.trace!(ContextTracking.context(), $name)
+            save(c)
+            push!(c.path, $name)
             $(def[:body])
         finally
-            restore(ContextTracking.context())
+            pop!(c.path)
+            restore(c)
         end
     end
     return esc(combinedef(def))

--- a/src/types.jl
+++ b/src/types.jl
@@ -14,5 +14,7 @@ struct Context{T}
     id::UInt
     "History of context data"
     history::Stack{T}
+    "Call path"
+    path::Vector{Symbol}
 end
 

--- a/test/test_trace.jl
+++ b/test/test_trace.jl
@@ -8,11 +8,13 @@ module TracingTest
         @memo x = 1
         me = "not visible downstream"
         bar()
+        @test context().path == [:foo]
     end
 
     @ctx function bar()
         @memo y = 2
         baz()
+        @test context().path == [:foo, :bar]
     end
 
     @ctx function baz()

--- a/test/test_trace.jl
+++ b/test/test_trace.jl
@@ -17,7 +17,7 @@ module TracingTest
 
     @ctx function baz()
         c = context()
-        @test call_path(c) == [:foo, :bar, :baz]
+        @test c.path == [:foo, :bar, :baz]
         @test c.data[:x] == 1
         @test c.data[:y] == 2
         @test !haskey(c.data, :me)


### PR DESCRIPTION
Storing the call path in the context Dict has been quite awkward.  This PR redesigned the tracing of call path by making it a regular field of the `Context` object.  Rather than relying on the context stack to maintain the path, the `@ctx` macro now push/pop the function symbol to the array.

Unsurprisingly, this is a cleaner design with less code.  Also got rid of the `call_path` function.