### PR TITLE
Macro escape issue and exports

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ContextTracking"
 uuid = "6cbdd853-f5b8-41ca-9b66-f060deb7aec3"
 authors = ["Tom Kwong <tk3369@gmail.com>"]
-version = "0.2.1"
+version = "0.3.0"
 
 [deps]
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"

--- a/src/ContextTracking.jl
+++ b/src/ContextTracking.jl
@@ -6,7 +6,7 @@ using DocStringExtensions
 using ExprTools: combinedef, splitdef
 
 export Context
-export context, save, restore
+export context
 export @ctx, @memo
 
 include("types.jl")

--- a/src/trace.jl
+++ b/src/trace.jl
@@ -44,7 +44,7 @@ macro memo(ex)
     sym = QuoteNode(x)
     val = gensym()
     return esc(quote
-        $val =$ex
+        $val = $ex
         push!(ContextTracking.context(), $sym => $val)
     end)
 end

--- a/test/test_context.jl
+++ b/test/test_context.jl
@@ -22,7 +22,7 @@
     @test c["key2"] == "hey"
 
     # save current context to stack
-    save(c)
+    ContextTracking.save(c)
     @test c.generations == 2   # current + one saved context
     @test length(c) == 2
 
@@ -32,7 +32,7 @@
     @test sort(collect(keys(c.data))) == ["key1", "key2", "key3"]
 
     # restore the prior context
-    restore(c)
+    ContextTracking.restore(c)
     @test c.generations == 1
     @test length(c) == 2
     @test sort(collect(keys(c.data))) == ["key1", "key2"]


### PR DESCRIPTION
This PR contains two changes:

1. Fix for macro escape issue
2. Remove exports for `save` and `restore` (See #15)

### Details

Currently, the variable `c` isn't escaped correctly as shown below:
```
julia> @macroexpand(@ctx function foo()
         bar()
       end)
:(function foo()
      #= /home/admin/opensource/ContextTracking.jl/src/trace.jl:14 =#
      c = ContextTracking.context()
      #= /home/admin/opensource/ContextTracking.jl/src/trace.jl:15 =#
      try
          #= /home/admin/opensource/ContextTracking.jl/src/trace.jl:16 =#
          save(c)
          #= /home/admin/opensource/ContextTracking.jl/src/trace.jl:17 =#
          push!(c.path, :foo)
          #= /home/admin/opensource/ContextTracking.jl/src/trace.jl:18 =#
          begin
              #= REPL[2]:1 =#
              #= REPL[2]:2 =#
              bar()
          end
      finally
          #= /home/admin/opensource/ContextTracking.jl/src/trace.jl:20 =#
          pop!(c.path)
          #= /home/admin/opensource/ContextTracking.jl/src/trace.jl:21 =#
          restore(c)
      end
  end)
```

How it looks like with this PR:
```
julia> @macroexpand(@ctx function foo()
         bar()
       end)
:(function foo()
      #= /home/admin/opensource/ContextTracking.jl/src/trace.jl:15 =#
      var"##253" = ContextTracking.context()
      #= /home/admin/opensource/ContextTracking.jl/src/trace.jl:16 =#
      try
          #= /home/admin/opensource/ContextTracking.jl/src/trace.jl:17 =#
          ContextTracking.save(var"##253")
          #= /home/admin/opensource/ContextTracking.jl/src/trace.jl:18 =#
          push!((var"##253").path, :foo)
          #= /home/admin/opensource/ContextTracking.jl/src/trace.jl:19 =#
          begin
              #= REPL[2]:1 =#
              #= REPL[2]:2 =#
              bar()
          end
      finally
          #= /home/admin/opensource/ContextTracking.jl/src/trace.jl:21 =#
          pop!((var"##253").path)
          #= /home/admin/opensource/ContextTracking.jl/src/trace.jl:22 =#
          ContextTracking.restore(var"##253")
      end
  end)
```